### PR TITLE
PWEB-3973

### DIFF
--- a/DDx/DDx.xcodeproj/project.pbxproj
+++ b/DDx/DDx.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		4380763418E1DA1500A6E8CD /* gear.png in Resources */ = {isa = PBXBuildFile; fileRef = 4380763318E1DA1500A6E8CD /* gear.png */; };
 		4380763618E1DB9F00A6E8CD /* persons.png in Resources */ = {isa = PBXBuildFile; fileRef = 4380763518E1DB9F00A6E8CD /* persons.png */; };
 		4380763C18E1E14500A6E8CD /* invalidate-persons-small.png in Resources */ = {isa = PBXBuildFile; fileRef = 4380763B18E1E14500A6E8CD /* invalidate-persons-small.png */; };
+		43D7E1CC18E9F8FF00A3AF66 /* DDxServerServicePing.m in Sources */ = {isa = PBXBuildFile; fileRef = 43D7E1CB18E9F8FF00A3AF66 /* DDxServerServicePing.m */; };
+		43D7E1D018EA059600A3AF66 /* DDxRoundtripPing.m in Sources */ = {isa = PBXBuildFile; fileRef = 43D7E1CF18EA059600A3AF66 /* DDxRoundtripPing.m */; };
 		6176B737FBCB4BDE8527A167 /* libPods-DDx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F8740A2D9046447A9167E838 /* libPods-DDx.a */; };
 		83F853D218A3D4E400AD0E5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F853D118A3D4E400AD0E5E /* Foundation.framework */; };
 		83F853D418A3D4E400AD0E5E /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F853D318A3D4E400AD0E5E /* CoreGraphics.framework */; };
@@ -196,6 +198,10 @@
 		4380763318E1DA1500A6E8CD /* gear.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = gear.png; sourceTree = "<group>"; };
 		4380763518E1DB9F00A6E8CD /* persons.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = persons.png; sourceTree = "<group>"; };
 		4380763B18E1E14500A6E8CD /* invalidate-persons-small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "invalidate-persons-small.png"; sourceTree = "<group>"; };
+		43D7E1CA18E9F8FF00A3AF66 /* DDxServerServicePing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDxServerServicePing.h; sourceTree = "<group>"; };
+		43D7E1CB18E9F8FF00A3AF66 /* DDxServerServicePing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDxServerServicePing.m; sourceTree = "<group>"; };
+		43D7E1CE18EA059600A3AF66 /* DDxRoundtripPing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDxRoundtripPing.h; sourceTree = "<group>"; };
+		43D7E1CF18EA059600A3AF66 /* DDxRoundtripPing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDxRoundtripPing.m; sourceTree = "<group>"; };
 		83F853CE18A3D4E400AD0E5E /* DDx.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DDx.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		83F853D118A3D4E400AD0E5E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		83F853D318A3D4E400AD0E5E /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -327,6 +333,17 @@
 			name = "Old PureWeb UI";
 			sourceTree = "<group>";
 		};
+		43D7E1C918E9F8DA00A3AF66 /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				43D7E1CA18E9F8FF00A3AF66 /* DDxServerServicePing.h */,
+				43D7E1CB18E9F8FF00A3AF66 /* DDxServerServicePing.m */,
+				43D7E1CE18EA059600A3AF66 /* DDxRoundtripPing.h */,
+				43D7E1CF18EA059600A3AF66 /* DDxRoundtripPing.m */,
+			);
+			name = Utility;
+			sourceTree = "<group>";
+		};
 		83F853C518A3D4E400AD0E5E = {
 			isa = PBXGroup;
 			children = (
@@ -361,6 +378,7 @@
 		83F853D718A3D4E400AD0E5E /* DDx */ = {
 			isa = PBXGroup;
 			children = (
+				43D7E1C918E9F8DA00A3AF66 /* Utility */,
 				438075E818E0BAD900A6E8CD /* Old PureWeb UI */,
 				438075E718E0BA1B00A6E8CD /* Supporting Files */,
 				4380758918E0B96A00A6E8CD /* AppDelegate.h */,
@@ -566,6 +584,7 @@
 				4380762518E0BB4000A6E8CD /* PWLoginViewController.m in Sources */,
 				438075A518E0B96A00A6E8CD /* AspectRatioViewController.m in Sources */,
 				4380762618E0BB4000A6E8CD /* PWDiagnosticViewDelegate.m in Sources */,
+				43D7E1CC18E9F8FF00A3AF66 /* DDxServerServicePing.m in Sources */,
 				4380762C18E0BB4000A6E8CD /* PWAppStateView.m in Sources */,
 				4380761818E0BB4000A6E8CD /* PWTouchButtonView.m in Sources */,
 				4380761918E0BB4000A6E8CD /* PWTimingView.m in Sources */,
@@ -575,6 +594,7 @@
 				4380762018E0BB4000A6E8CD /* PWOptionViewController.m in Sources */,
 				4380761518E0BB4000A6E8CD /* UIAlertView+PWUtils.m in Sources */,
 				4380761E18E0BB4000A6E8CD /* PWProfilerView.m in Sources */,
+				43D7E1D018EA059600A3AF66 /* DDxRoundtripPing.m in Sources */,
 				4380762218E0BB4000A6E8CD /* PWNavigationController.m in Sources */,
 				438075B218E0B96A00A6E8CD /* TabViewController.m in Sources */,
 				4380761A18E0BB4000A6E8CD /* PWTiming.m in Sources */,

--- a/DDx/DDx/DDxRoundtripPing.h
+++ b/DDx/DDx/DDxRoundtripPing.h
@@ -1,0 +1,17 @@
+//
+//  DDxRoundtripPing.h
+//  DDx
+//
+//  Created by Chris Burns on 3/31/14.
+//  Copyright (c) 2014 Calgary Scientific Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef void (^DDxPingCompletion)(int numPings, double average, NSArray *times);
+
+@interface DDxRoundtripPing : NSObject
+
+- (void) ping:(DDxPingCompletion) completion;
+
+@end

--- a/DDx/DDx/DDxRoundtripPing.m
+++ b/DDx/DDx/DDxRoundtripPing.m
@@ -1,0 +1,89 @@
+//
+//  DDxRoundtripPing.m
+//  DDx
+//
+//  Created by Chris Burns on 3/31/14.
+//  Copyright (c) 2014 Calgary Scientific Inc. All rights reserved.
+//
+
+#import "DDxRoundtripPing.h"
+
+#import <PureWeb/PureWeb.h>
+
+@interface DDxRoundtripPing ()
+
+@property NSInteger totalPings;
+@property NSInteger pingsCompleted;
+
+@property NSMutableArray *pingResults;
+
+@property (nonatomic, copy) DDxPingCompletion completion;
+
+@end
+
+
+@implementation DDxRoundtripPing
+
+- (void) ping:(DDxPingCompletion) completion {
+    
+    self.completion = completion;
+    
+    [self start];
+    
+}
+
+- (void) start
+{
+    self.totalPings = 10;
+    self.pingsCompleted = 0;
+    self.pingResults = [NSMutableArray array];
+    
+    [self sendPing];
+
+}
+
+
+- (void) finish
+{
+    //invoke the completion block with the required values
+    __block NSNumber *pingSum = 0;
+    [self.pingResults enumerateObjectsUsingBlock:^(NSNumber *result, NSUInteger idx, BOOL *stop) {
+        
+        pingSum = @([pingSum floatValue] + [result floatValue]);
+    }];
+    
+    float pingAverage = [pingSum floatValue] / (float) self.totalPings;
+    
+    self.completion(self.totalPings, pingAverage, self.pingResults);
+}
+
+
+- (void)sendPing
+{
+
+    NSDate *pingStart = [NSDate date];
+    
+    //(???) how are we able to edit self.pingsCompleted if its not marked as being inside a __block property
+    [[PWFramework sharedInstance].client queueCommand:@"DDxRoundtripPing"
+                                       withParameters:nil
+                                    isDeferredCommand:NO
+                                           onComplete:^(PWCommandResponseEventArgs *args) {
+                                               
+                                               self.pingsCompleted++;
+                                               
+                                               //store the result from the ping
+                                               float result = ([pingStart timeIntervalSinceNow] * -1000.0); //convert to positive milliseconds
+                                               [self.pingResults addObject:@(result)];
+
+                                               //determine if additional pings are required
+                                               if (self.pingsCompleted < self.totalPings) {
+                                                   
+                                                   [self sendPing];
+                                               }
+                                               else {
+                                                   
+                                                   [self finish];
+                                               }
+                                           }];
+}
+@end

--- a/DDx/DDx/DDxServerServicePing.h
+++ b/DDx/DDx/DDxServerServicePing.h
@@ -1,0 +1,17 @@
+//
+//  DDxServerServicePing.h
+//  DDx
+//
+//  Created by Chris Burns on 3/31/14.
+//  Copyright (c) 2014 Calgary Scientific Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef void (^DDxPingCompletion)(int numPings, double average, NSArray *times);
+
+@interface DDxServerServicePing : NSObject
+
+- (void) ping:(DDxPingCompletion) completion;
+
+@end

--- a/DDx/DDx/DDxServerServicePing.m
+++ b/DDx/DDx/DDxServerServicePing.m
@@ -1,0 +1,88 @@
+#import "DDxServerServicePing.h"
+
+#import <PureWeb/PureWeb.h>
+
+@interface DDxServerServicePing ()
+
+@property NSInteger totalPings;
+@property NSMutableArray *pingResults;
+
+@property (nonatomic, copy) DDxPingCompletion completion;
+
+@end
+
+
+@implementation DDxServerServicePing
+
+
+/* a service server ping measures the ping between the service and the server which can be located on different machines. for */
+- (void) ping:(DDxPingCompletion) completion {
+    
+    self.completion = completion;
+    
+    [self start];
+    
+    [self triggerPing];
+}
+
+- (void) start
+{
+    self.totalPings = 10;
+    
+    self.pingResults = [NSMutableArray array];
+    
+    //listen to app state for a change to the number of remaining pings
+    [[PWFramework sharedInstance].state.stateManager addValueChangedHandler:@"DDxServiceServerPingResponseCount"
+                                                                     target:self
+                                                                     action:@selector(didReceivePingResponse:)];
+}
+
+- (void) finish
+{
+    //remove the listener on app state
+    [[PWFramework sharedInstance].state.stateManager removeValueChangedHandler:@"DDxServiceServerPingResponseCount" target:self action:@selector(didReceivePingResponse:)];
+    
+    //invoke the completion block with the required values
+    __block NSNumber *pingSum = 0;
+    [self.pingResults enumerateObjectsUsingBlock:^(NSNumber *result, NSUInteger idx, BOOL *stop) {
+        
+        pingSum = @([pingSum floatValue] + [result floatValue]);
+    }];
+    
+    float pingAverage = [pingSum floatValue] / (float) self.totalPings;
+    
+    self.completion(self.totalPings, pingAverage, self.pingResults);
+
+}
+
+- (void) triggerPing
+{
+    [[PWFramework sharedInstance].client queueCommand:@"DDxServiceServerPing"
+                                       withParameters:nil
+                                    isDeferredCommand:NO
+                                           onComplete:^(PWCommandResponseEventArgs *args) {
+                                               
+                                           }];
+}
+
+
+- (void) didReceivePingResponse: (PWValueChangedEventArgs *) args {
+    
+    //capture the results
+    float result = [[[PWFramework sharedInstance].state.stateManager getValue:@"DDxServiceServerPingResponse"] floatValue];
+    [self.pingResults addObject:@(result)];
+    
+    //determine if the ping process should continue
+    NSInteger completedPings = [args.newValue integerValue];
+    
+    if (completedPings < self.totalPings) {
+        
+        [self triggerPing];
+    }
+    else {
+        
+        [self finish];
+    }
+}
+
+@end

--- a/DDx/DDx/TabViewController.h
+++ b/DDx/DDx/TabViewController.h
@@ -17,18 +17,12 @@
     NSString *_sharedURL;
     UIButton *_optionsButton;
     UIButton *_shareButton;
-    UISegmentedControl *_pingButton;
-    NSDate *_pingStartDate;
-    NSInteger _pingCount;
     UIAlertView *_sendingPingsView;
 }
 
 @property (nonatomic, strong) NSString *sharedURL;
 @property (nonatomic, strong) UIButton *optionsButton;
 @property (nonatomic, strong) UIButton *shareButton;
-@property (nonatomic, strong) UISegmentedControl *pingButton;
-@property (nonatomic, strong) NSDate *pingStartDate;
-@property (nonatomic) NSInteger pingCount;
 @property (nonatomic, strong) UIAlertView *sendingPingsView;
 
 @end


### PR DESCRIPTION
added two new classes to encapsulate the logic behind roundtrip and service server pings. provided a block based completion for both, removed a bunch older code for performing the ping from the view controller.

also, I'll put a long running question here thats come up twice when working with blocks. according to my understanding of the block rules, we need to add a __block modifier to any enclosing scope which the block needs to modify. that is done, for example, when we sum up the values in an array. but it does't appear to be necessary when the values themselves are properties on an object, for example, when we increment self.pingsCompleted. Is this because the block already contains a strong reference back to self? why don't we need to include a block modifier in the pingsCompleted property?
