### PR TITLE
PWEB-4214 

### DIFF
--- a/DDx/DDx/TabViewController.m
+++ b/DDx/DDx/TabViewController.m
@@ -85,6 +85,10 @@
             [(id<PWNavigationControllerDelegate>)v viewWasPopped];
 }
 
+- (void) viewWasPushed {
+    
+}
+
 - (void)setViewControllers:(NSArray *)viewControllers animated:(BOOL)animated {
     [super setViewControllers:viewControllers animated:animated];
     [self hideOptionsButtonForViewController:[self.viewControllers objectAtIndex:0]];


### PR DESCRIPTION
the hasty removal of brackets caused the viewWasPushed to be lost, which is evidently required
