### PR TITLE
PWEB-4196 fixes related to backgrounding & synchronizing settings (needs comments and feedback)

### DIFF
--- a/Asteroids/Asteroids/Asteroids-Info.plist
+++ b/Asteroids/Asteroids/Asteroids-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIApplicationExitsOnSuspend</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/PureWebUI/PureWebUI/LoginViewController.m
+++ b/PureWebUI/PureWebUI/LoginViewController.m
@@ -5,6 +5,8 @@
 
 #import "LoginViewController.h"
 
+#import <PureWeb/PureWeb.h>
+
 @interface LoginViewController () <UITextFieldDelegate>
 
 @property (weak, nonatomic) IBOutlet UITextField *usernameField;
@@ -19,9 +21,27 @@
 
 - (void)viewDidLoad
 {
+    [self loadCredentials];
+    
+    //setup delegates
+    self.usernameField.delegate = self;
+    self.passwordField.delegate = self;
+    
+    [super viewDidLoad];
+}
+
+
+- (void)loadCredentials {
+    
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    
+    //load the username and password from the settings
     self.usernameField.text = [[NSUserDefaults standardUserDefaults] stringForKey:@"pureweb_username"];
     self.passwordField.text = [[NSUserDefaults standardUserDefaults] stringForKey:@"pureweb_password"];
     
+    [self loadCollaborationCredentials];
+    
+    //check if the settings should enable the button
     if(self.usernameField.text.length > 0 && self.passwordField.text.length > 0) {
         self.connectButton.enabled = YES;
     }
@@ -29,14 +49,27 @@
         
         self.connectButton.enabled = NO;
     }
-    
-    //setup delegates
-    self.usernameField.delegate = self;
-    self.passwordField.delegate = self;
-
-    
-    [super viewDidLoad];
 }
+
+- (void)loadCollaborationCredentials {
+    //load the display name and email as well
+    NSString *name = [[NSUserDefaults standardUserDefaults] stringForKey:@"pureweb_collab_name"];
+    NSString *email = [[NSUserDefaults standardUserDefaults] stringForKey:@"pureweb_collab_email"];
+    
+    //only register these names with the collaboration manage if they are valid
+    if (![name isEqualToString:@""]) {
+        
+        [[PWFramework sharedInstance].collaborationManager updateUserInfo:@"Name" value:name];
+    }
+    
+    if (![email isEqualToString:@""]) {
+        
+        [[PWFramework sharedInstance].collaborationManager updateUserInfo:@"Email" value:email];
+        
+    }
+}
+
+
 
 - (void) loginFailed
 {

--- a/Scribble/Scribble/Scribble-Info.plist
+++ b/Scribble/Scribble/Scribble-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIApplicationExitsOnSuspend</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
one of the issues that sherri and terry had with the new samples was a difficulty changing the username and url whenever the application was newly loaded. the workflow was essentially (a) install the app (b) background the app and change the settings and (c) return to the app. 

since the app loaded the credentials from the settings bundle on startup, it was necessary to terminate and reload the app before those changes took effect. so the question became how to synchronize the changes to the settings bundle with the application which was already running but was currently backgrounded. this could produce a variety of edge cases, what if the app was running and loaded, what if the app was loaded but disconnected by a timeout, what if the app had login credentials from the screen already, etc. 

the current behavior of DDx (the last of the old samples) is a little different. whenever the user backgrounds the app the session is shut down and you return to the login screen. in effect, you can't keep an active PW session running the background. given that, I thought the simplest thing to do was to terminate the app on suspension, this allows us to get the same behavior as DDx but without introducing any new state or edge cases. 

i'd appreciate any comments or feedback or alternative ideas on this.
