### PR TITLE
PWEB-5494 - Fix case were we have an app url with ddx:// as the scheme

### DIFF
--- a/DDx/DDx/PWLoginViewController.m
+++ b/DDx/DDx/PWLoginViewController.m
@@ -245,7 +245,8 @@ CGRect scrollframe;
     }
     else if ([self isAppSessionUrl:launchUrl])
     {
-        [_framework.client connect:self.serverHref];            
+        NSURL *newUrl = [self httpSchemeURL:[NSURL URLWithString:self.serverHref]];
+        [_framework.client connect:[newUrl absoluteString]];
     }
     else 
     {


### PR DESCRIPTION
With the previous change the app url redirect from the server now has ddx:// as the scheme instead of http://. This change replaces the ddx:// scheme with http:// before connect is called. Allowing the connect to proceed.